### PR TITLE
Persistence Node: HTML files from ui dir are not built

### DIFF
--- a/nodes/persistence-node/package.json
+++ b/nodes/persistence-node/package.json
@@ -26,10 +26,11 @@
     "wrapper"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json && yarn copy-ui-files",
     "dev": "ts-node src/main.ts",
     "start": "node bin/main.js",
     "test": "yarn test:jest",
+    "copy-ui-files": "rm -rf ./bin/ui/ && mkdir -p ./bin/ui/ && cp -r ./src/ui/ ./bin/ui/",
     "test:jest": "jest test --passWithNoTests"
   },
   "dependencies": {


### PR DESCRIPTION
Fixed by adding a new task in package.json, which will copy the UI files. We could move that to a shell script, but I thought that might be overkill for now.