### PR TITLE
Should not default to internal IPFS node if invalid provider URL is configured

### DIFF
--- a/nodes/persistence-node/src/config/IpfsConfig.ts
+++ b/nodes/persistence-node/src/config/IpfsConfig.ts
@@ -10,9 +10,14 @@ export class IpfsConfig {
 }
 
 function getValidUrlOrUndefined(url: string | undefined) {
+  if (url?.length === 0) {
+    return undefined;
+  }
+
   if (isValidUrl(url)) {
     return url;
   } else {
-    return undefined;
+    console.log("Invalid URL supplied for EXTERNAL_IPFS_PROVIDER setting");
+    process.exit();
   }
 }


### PR DESCRIPTION
Possible scenarios:
- `EXTERNAL_IPFS_PROVIDER` set to valid url - use that for IFPS provider
- `EXTERNAL_IPFS_PROVIDER` set to invalid url - throw error, kill process
- `EXTERNAL_IPFS_PROVIDER` set to empty string - use internal IPFS node
- `EXTERNAL_IPFS_PROVIDER` not present at all - use internal IPFS node (sane default, IMO better than throwing an error)