### PR TITLE
Reordered priority of ipfs hash processing

### DIFF
--- a/nodes/ens-contenthash-indexer-node/package.json
+++ b/nodes/ens-contenthash-indexer-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polywrap/ens-contenthash-indexer-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "bin/main.js",
   "types": "bin/main.d.ts",
   "author": "nerfZael",

--- a/nodes/persistence-node/package.json
+++ b/nodes/persistence-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polywrap/persistence-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "bin/main.js",
   "types": "bin/main.d.ts",
   "author": "nerfZael",

--- a/nodes/persistence-node/src/constants/version.ts
+++ b/nodes/persistence-node/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.4.0"; // Version of the node.
+export const VERSION = "0.4.1"; // Version of the node.

--- a/nodes/persistence-node/src/services/PersistenceService.ts
+++ b/nodes/persistence-node/src/services/PersistenceService.ts
@@ -74,7 +74,6 @@ export class PersistenceService {
     return newTimestamp[0] * 1000 + newTimestamp[1] / 1000000;
   }
 
-
   private async sleepUntilNextPersistenceRun(lastTimestamp: [number, number]): Promise<void> {
     const milisecondsFromLastRun = this.getMilisecondsFromLastRun(lastTimestamp);
 


### PR DESCRIPTION
Processing first ipfs hashed to track, then to untrack and lastly the unresponsive hashes. If it takes more than persistenceIntervalSeconds to process all new ipfs hashes, then the process restarts to minimize the time it takes to track new hashes