### PR TITLE
fix: properly strip leading path seperator for single files

### DIFF
--- a/nodes/persistence-node/package.json
+++ b/nodes/persistence-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polywrap/persistence-node",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "main": "bin/main.js",
   "types": "bin/main.d.ts",
   "author": "nerfZael",

--- a/nodes/persistence-node/src/constants/version.ts
+++ b/nodes/persistence-node/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.14.9"; // Version of the node.
+export const VERSION = "0.14.10"; // Version of the node.

--- a/nodes/persistence-node/src/services/gateway-server/GatewayServer.ts
+++ b/nodes/persistence-node/src/services/gateway-server/GatewayServer.ts
@@ -58,9 +58,19 @@ function prefix(words: string[]){
 }
 
 export const stripBasePath = (files: InMemoryFile[]) => {
-  if (files.length === 0 || files.length === 1) {
+  if (files.length === 0) {
     return files;
+  } else if (files.length === 1) {
+    // Strip any leading path seperators
+    const file = files[0];
+    const lastSeperator = file.path.lastIndexOf("/");
+    return [{
+      ...file,
+      path: file.path.substring(lastSeperator + 1)
+    }];
   }
+
+  // Strip the common base path
   let basePath = prefix(files.map(f => f.path + "/"));
   const lastPathSeparator = Math.max(basePath.lastIndexOf("/"), basePath.lastIndexOf("\\"));
   basePath = basePath.slice(0, lastPathSeparator + 1);


### PR DESCRIPTION
When publishing wraps that are a single file (i.e. interfaces), `api/v0/add` fails due to leading path separators not being removed.